### PR TITLE
Repository change: Remove claudiodekker/ungoogled-chromium-macos

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,6 +30,7 @@
   "permissions": [
     "alarms",
     "downloads",
+    "notifications",
     "storage"
   ],
   "version": "0.0.0"

--- a/public/repositories.js
+++ b/public/repositories.js
@@ -1,33 +1,6 @@
 import { ENUMS, HELPERS } from './support.js'
 
 export default {
-  'claudiodekker/ungoogled-chromium-macos': async (release) => {
-    const filenamePattern = /ungoogled-chromium[_-](?<version>\d+(?:[.]\d+)+)-(?<revision>\d+)\.(?<package_revision>\d+)_(?<arch>x86-64|arm64)-macos-signed\.dmg/
-    const hashesPattern = /disk image `(?<name>ungoogled-chromium_.*)`: \n\n```\nmd5: (?<md5>.*)\nsha1: (?<sha1>.*)\nsha256: (?<sha256>.*)\n```/g
-
-    const hashes = HELPERS.extractMany(release.body, hashesPattern)
-
-    return HELPERS.githubReleaseDefaultMapper(release, (release) => ({
-      ...release,
-      name: 'Ungoogled-Chromium ' + release.tag_name.split('_')[0],
-      assets: release.assets.map((asset) => {
-        const assetDetails = HELPERS.extract(asset.name, filenamePattern)
-        const assetHashes = hashes.find((hash) => hash.name === asset.name)
-
-        return {
-          ...asset,
-          arch: assetDetails.arch,
-          os: ENUMS.OS.macos,
-          codesigned: true,
-          hashes: {
-            md5: assetHashes.md5,
-            sha1: assetHashes.sha1,
-            sha256: assetHashes.sha256,
-          },
-        }
-      }),
-    }))
-  },
   'ungoogled-software/ungoogled-chromium-archlinux': async (release) => {
     const pattern = /ungoogled-chromium[_-](?:(?<debug>debug)[_-])?(?<version>\d+(?:[.]\d+)+)-(?<revision>\d+)-(?<arch>x86_64|arm64)\.pkg\.tar\.zst/g
     const hashesPattern = /(?<sha256>[A-Fa-f0-9]{64}) {2}(?<name>ungoogled-chromium.*?\.pkg\.tar\.zst)\n/g

--- a/public/store.js
+++ b/public/store.js
@@ -19,7 +19,7 @@ export const store = {
   getPlatformInfo: () => HELPERS.promisify(chrome.runtime, 'getPlatformInfo')(),
 
   setRepository: (repository) => storage.set({ repository }),
-  getRepository: storage.getOrDefault('repository', 'claudiodekker/ungoogled-chromium-macos'),
+  getRepository: storage.getOrDefault('repository', 'ungoogled-software/ungoogled-chromium-macos'),
 
   setOSFilter: (OSFilter) => storage.set({ OSFilter }),
   getOSFilter: storage.getOrDefault('OSFilter', 'detect'),

--- a/public/store.js
+++ b/public/store.js
@@ -20,6 +20,7 @@ export const store = {
 
   setRepository: (repository) => storage.set({ repository }),
   getRepository: storage.getOrDefault('repository', 'ungoogled-software/ungoogled-chromium-macos'),
+  resetDefaultRepository: () => store.setRepository('ungoogled-software/ungoogled-chromium-macos'),
 
   setOSFilter: (OSFilter) => storage.set({ OSFilter }),
   getOSFilter: storage.getOrDefault('OSFilter', 'detect'),


### PR DESCRIPTION
The official Ungoogled Chromium builds are now notarized/signed, meaning there was no use in producing builds ourselves. To reflect this, we've removed and changed the default setting, and will notify users if they're still configured to check the outdated repository.

https://github.com/ungoogled-software/ungoogled-chromium-macos/tree/8e6e5a5ee0fbff804ef2811701b884ab7bf0fc14?tab=readme-ov-file#announcements